### PR TITLE
Fix not checking existence in getOne.

### DIFF
--- a/src/question/question.resolver.ts
+++ b/src/question/question.resolver.ts
@@ -11,6 +11,7 @@ import { Question } from "./entities/question.entity";
 import { CreateQuestionInput } from "./dto/create-question.input";
 import { UpdateQuestionInput } from "./dto/update-question.input";
 import { Answer } from "@src/answer/entities/answer.entity";
+import { NotFoundException } from "@nestjs/common";
 
 @Resolver(() => Question)
 export class QuestionResolver {
@@ -25,8 +26,12 @@ export class QuestionResolver {
   }
 
   @Query(() => Question, { name: "getOneQuestion" })
-  findOne(@Args("id") id: string) {
-    return this.questionService.findOne(id);
+  async findOne(@Args("id") id: string) {
+    const question = await this.questionService.findOne(id);
+    if (!question) {
+      throw new NotFoundException("Question with given id not found");
+    }
+    return question;
   }
 
   @Mutation(() => Question)

--- a/src/quiz/quiz.resolver.ts
+++ b/src/quiz/quiz.resolver.ts
@@ -3,7 +3,7 @@ import { QuizService } from "./quiz.service";
 import { Quiz } from "./entities/quiz.entity";
 import { CreateQuizInput } from "./dto/create-quiz.input";
 import { UpdateQuizInput } from "./dto/update-quiz.input";
-
+import { NotFoundException } from "@nestjs/common";
 @Resolver(() => Quiz)
 export class QuizResolver {
   constructor(private readonly quizService: QuizService) {}
@@ -19,8 +19,12 @@ export class QuizResolver {
   }
 
   @Query(() => Quiz, { name: "getOneQuiz" })
-  findOne(@Args("id") id: string) {
-    return this.quizService.findOne(id);
+  async findOne(@Args("id") id: string) {
+    const quiz = await this.quizService.findOne(id);
+    if (!quiz) {
+      throw new NotFoundException("Quiz with given id not found");
+    }
+    return quiz;
   }
 
   @Mutation(() => Quiz)

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -60,7 +60,7 @@ export class QuizService {
       );
     }
 
-    if (!this.findOne(updateQuizInput.id)) {
+    if (!(await this.findOne(updateQuizInput.id))) {
       throw new NotFoundException(
         `Quiz with id ${updateQuizInput.id} not found`
       );


### PR DESCRIPTION
While resolving getOneQuiz/Question there was no "existence checking". Resoved didn't check if service returned null.
There was similar bug in update quiz- method did not await.

Concerns: #15